### PR TITLE
debian buster fix for install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,7 @@ make
 make install
 cd ../
 
-git clone https://github.com/tihmstar/usbmuxd2.git
+git clone https://github.com/jkcoxson/usbmuxd2
 cd usbmuxd2
 ./autogen.sh
 ./autogen.sh


### PR DESCRIPTION
This updates one of the Repositories that the command clones. This should fix usb/wifi connectivity on a raspberry pi.