### PR TITLE
Fix: change Execution-policy

### DIFF
--- a/Windows_files_workaround/SshKeySetup/RestartSSH.bat
+++ b/Windows_files_workaround/SshKeySetup/RestartSSH.bat
@@ -1,2 +1,2 @@
-
+powershell -command "Start-Process Powershell -Verb RunAs \"-command "Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned \"
 powershell -command "   Start-Process PowerShell -Verb RunAs \""-Command `\""cd '%cd%'; & '%~dp0\PS1scripts\RestartSSH.ps1';`\""\""   "

--- a/Windows_files_workaround/SshKeySetup/SetupSSH.bat
+++ b/Windows_files_workaround/SshKeySetup/SetupSSH.bat
@@ -1,2 +1,2 @@
-
-powershell -command "   Start-Process PowerShell -Verb RunAs \""-Command `\""cd '%cd%'; & '%~dp0\PS1scripts\SetupSSH.ps1';`\""\""   "
+powershell -command "Start-Process Powershell -Verb RunAs \"-command "Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned \"
+powershell -command "Start-Process PowerShell -Verb RunAs \""-Command `\""cd '%cd%'; & '%~dp0\PS1scripts\SetupSSH.ps1';`\""\""   "


### PR DESCRIPTION
This allows computers that don't accept executing ps1 files to allow the ones in the setupSSH and restartSSH to be able to run ps1 files for PowerShell.

note: enable GitHub pages for \root for the GitHub pages tutorial to be seen